### PR TITLE
Fix ec2 graviton name and instanceType is inconsistent

### DIFF
--- a/examples/sample_graviton_ekscluster.yaml
+++ b/examples/sample_graviton_ekscluster.yaml
@@ -60,7 +60,7 @@ managedNodeGroups:
       k8s.io/cluster-autoscaler/enabled: "true"
       k8s.io/cluster-autoscaler/eks-nvme: "owned"  
   - name: C6g_8
-    instanceType: c6.8xlarge
+    instanceType: c6g.8xlarge
     availabilityZones: [{REGION}"a"] 
     preBootstrapCommands:
       - "IDX=1;for DEV in /dev/nvme[1-9]n1;do sudo mkfs.xfs ${DEV}; sudo mkdir -p /local${IDX}; sudo echo ${DEV} /local${IDX} xfs defaults,noatime 1 2 >> /etc/fstab; IDX=$((${IDX} + 1)); done"


### PR DESCRIPTION
*Issue #, if available:*
name and instanceType is inconsistent
*Description of changes:*
change instanceType to `c6g.8xlarge`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
