### PR TITLE
Fix execution time rounding to 9 decimal places before writing to csv files

### DIFF
--- a/benchmark/src/main/scala/com/amazonaws/eks/tpcds/BenchmarkSQL.scala
+++ b/benchmark/src/main/scala/com/amazonaws/eks/tpcds/BenchmarkSQL.scala
@@ -64,7 +64,7 @@ object BenchmarkSQL {
     // Summarize results
     val result = specificResultTable
       .withColumn("result", explode(col("results")))
-      .withColumn("executionSeconds", col("result.executionTime")/1000)
+      .withColumn("executionSeconds", round(col("result.executionTime")/1000, 9))
       .withColumn("queryName", col("result.name"))
     result.select("iteration", "queryName", "executionSeconds").show()
     println(s"Final results at $resultPath")


### PR DESCRIPTION

*Issue #, if available:*
- Currently, the benchmark results are saved to CSV files which contain execution time for each query, stored as decimal values. When using MS Excel, the CSV files need to be converted, otherwise some decimal values (with 15 digits) are treated as string. This can result in discrepancies - for example, while calculating sum of all queries.

*Description of changes:*
- In this PR, we round the decimal values to 9 digits for "execution time" column before writing to the CSV file. 