### PR TITLE
Tpcds v2.13 iceberg -- Add write benchmark support 

### DIFF
--- a/benchmark/src/main/scala/com/amazonaws/eks/tpcds/BenchmarkSQL.scala
+++ b/benchmark/src/main/scala/com/amazonaws/eks/tpcds/BenchmarkSQL.scala
@@ -57,7 +57,8 @@ object BenchmarkSQL {
       filtered_queries,
       iterations = iterations,
       resultLocation = resultLocation,
-      forkThread = true)
+      forkThread = true,
+      isWriteBenchmark = benchmarkType == "write")
 
     experiment.waitForFinish(timeout)
 

--- a/benchmark/src/main/scala/com/amazonaws/eks/tpcds/BenchmarkSQL.scala
+++ b/benchmark/src/main/scala/com/amazonaws/eks/tpcds/BenchmarkSQL.scala
@@ -18,12 +18,13 @@ object BenchmarkSQL {
     val filterQueries = Try(args(4).toString).getOrElse("")
     val onlyWarn = Try(args(5).toBoolean).getOrElse(false)
     val databaseName = Try(args(6).toString).getOrElse("tpcds_db")
+    val benchmarkType = Try(args(7).toString).getOrElse("read")
 
     val timeout = 24*60*60
 
     val spark = SparkSession
       .builder
-      .appName(s"TPCDS SQL Benchmark $scaleFactor GB")
+      .appName(s"TPCDS SQL $benchmarkType Benchmark with $scaleFactor GB")
       .getOrCreate()
 
     if (onlyWarn) {
@@ -41,9 +42,14 @@ object BenchmarkSQL {
       query_filter = filterQueries.split(",").toSeq
     }
 
+    val queries = benchmarkType match {
+      case "read" => tpcds.tpcds2_13Queries
+      case "write" => tpcds.mergeQueries
+    }
+
     val filtered_queries = query_filter match {
-      case Seq() => tpcds.tpcds2_13Queries
-      case _ => tpcds.tpcds2_13Queries.filter(q => query_filter.contains(q.name))
+      case Seq() => queries
+      case _ => queries.filter(q => query_filter.contains(q.name))
     }
 
     // Start experiment

--- a/benchmark/src/main/scala/com/amazonaws/eks/tpcds/CleanUpMergeTables.scala
+++ b/benchmark/src/main/scala/com/amazonaws/eks/tpcds/CleanUpMergeTables.scala
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+package com.amazonaws.eks.tpcds
+
+import org.apache.log4j.{Level, LogManager}
+import org.apache.spark.sql.SparkSession
+import scala.util.{Failure, Success, Try}
+import sys.process._
+
+object CleanUpMergeTables {
+
+  def main(args: Array[String]): Unit = {
+    println("Starting CleanUpMergeTables")
+    require(args.length >= 3, "Usage: CleanUpMergeTables <parquetDir> <icebergDir> <database> [onlyWarn]")
+
+    val parquetSourceDirectory = args(0)
+    val icebergWarehouseDirectory = args(1)
+    val database = args(2)
+    val onlyWarn = args.lift(3).exists(_.toBoolean)
+
+    val spark = SparkSession.builder
+      .appName(s"TPCDS Clean up merge tables for $database")
+      .getOrCreate()
+
+    if (onlyWarn) {
+      println("Only WARN")
+      LogManager.getLogger("org").setLevel(Level.WARN)
+    }
+
+    Try {
+      spark.sql(s"DROP DATABASE IF EXISTS $database CASCADE")
+      spark.sql(s"DROP DATABASE IF EXISTS ${database}_iceberg CASCADE")
+
+      deleteS3Directory(parquetSourceDirectory)
+      deleteS3Directory(icebergWarehouseDirectory)
+    } match {
+      case Success(_) => println(s"Successfully cleaned up $database")
+      case Failure(e) =>
+        println(s"Failed to clean up $database: ${e.getMessage}")
+        e.printStackTrace()
+    }
+
+    spark.stop()
+  }
+
+  private def deleteS3Directory(path: String): Unit = {
+    val normalizedPath = if (path.endsWith("/")) path else s"$path/"
+    println(s"Deleting S3 directory: $normalizedPath")
+    val output = Seq("aws", "s3", "rm", normalizedPath, "--recursive").!!
+    println(output)
+  }
+}

--- a/benchmark/src/main/scala/com/amazonaws/eks/tpcds/CleanUpMergeTables.scala
+++ b/benchmark/src/main/scala/com/amazonaws/eks/tpcds/CleanUpMergeTables.scala
@@ -16,11 +16,12 @@ object CleanUpMergeTables {
 
     val parquetSourceDirectory = args(0)
     val icebergWarehouseDirectory = args(1)
-    val database = args(2)
+    val hive_database = args(2)
     val onlyWarn = args.lift(3).exists(_.toBoolean)
 
     val spark = SparkSession.builder
-      .appName(s"TPCDS Clean up merge tables for $database")
+      .appName(s"TPCDS Clean up merge tables for $hive_database")
+      .enableHiveSupport()
       .getOrCreate()
 
     if (onlyWarn) {
@@ -29,15 +30,14 @@ object CleanUpMergeTables {
     }
 
     Try {
-      spark.sql(s"DROP DATABASE IF EXISTS $database CASCADE")
-      spark.sql(s"DROP DATABASE IF EXISTS ${database}_iceberg CASCADE")
+      spark.sql(s"DROP DATABASE IF EXISTS $hive_database CASCADE")
 
       deleteS3Directory(parquetSourceDirectory)
       deleteS3Directory(icebergWarehouseDirectory)
     } match {
-      case Success(_) => println(s"Successfully cleaned up $database")
+      case Success(_) => println(s"Successfully cleaned up $hive_database")
       case Failure(e) =>
-        println(s"Failed to clean up $database: ${e.getMessage}")
+        println(s"Failed to clean up $hive_database: ${e.getMessage}")
         e.printStackTrace()
     }
 

--- a/benchmark/src/main/scala/com/amazonaws/eks/tpcds/CreateIcebergTables.scala
+++ b/benchmark/src/main/scala/com/amazonaws/eks/tpcds/CreateIcebergTables.scala
@@ -2,21 +2,20 @@
 // SPDX-License-Identifier: MIT-0
 package com.amazonaws.eks.tpcds
 
-import com.databricks.spark.sql.perf.tpcds.{TPCDS, TPCDSTables}
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.functions.col
+import com.databricks.spark.sql.perf.tpcds.TPCDSTables
 import org.apache.log4j.{Level, LogManager}
+import org.apache.spark.sql.SparkSession
+
 import scala.util.Try
 
 object CreateIcebergTables {
   def main(args: Array[String]) {
     val tpcdsDataDir = args(0)
     val dsdgenDir = args(1)
-    val format = Try(args(2).toString).getOrElse("parquet")
-    val scaleFactor = Try(args(3).toString).getOrElse("1")
+    val format = Try(args(2)).getOrElse("parquet")
+    val scaleFactor = Try(args(3)).getOrElse("1")
     val onlyWarn = Try(args(4).toBoolean).getOrElse(false)
-    val databaseName = Try(args(5).toString).getOrElse("tpcds_db_iceberg")
+    val databaseName = Try(args(5)).getOrElse("tpcds_db_iceberg")
     val useStringForCharAndVarchar = Try(args(6).toBoolean).getOrElse(false)
     val inferSchema = Try(args(7).toBoolean).getOrElse(false)
 
@@ -25,7 +24,7 @@ object CreateIcebergTables {
 
     val spark = SparkSession
       .builder
-      .appName(s"TPCDS SQL Benchmark $scaleFactor GB")
+      .appName(s"TPCDS SQL Benchmark create tables for read benchmark with scale $scaleFactor GB")
       .getOrCreate()
 
     if (onlyWarn) {

--- a/benchmark/src/main/scala/com/amazonaws/eks/tpcds/CreateIcebergTablesForWrites.scala
+++ b/benchmark/src/main/scala/com/amazonaws/eks/tpcds/CreateIcebergTablesForWrites.scala
@@ -1,0 +1,158 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+package com.amazonaws.eks.tpcds
+
+import com.amazonaws.eks.tpcds.TpcdsDdlStatements._
+import org.apache.log4j.{Level, LogManager}
+import org.apache.spark.sql.SparkSession
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.concurrent.duration.DurationInt
+import scala.sys.process._
+import scala.util.Try
+
+object CreateIcebergTablesForWrites {
+  def main(args: Array[String]): Unit = {
+    val lstBenchDataDir = args(0)
+    val deltaMergeSourcesDir = args(1)
+    val s3PathPrefixDestinationDir = args(2)
+    val format = Try(args(3)).getOrElse("parquet")
+    val scaleFactor = Try(args(4)).getOrElse("1")
+    val onlyWarn = Try(args(5).toBoolean).getOrElse(false)
+    val databaseName = Try(args(6)).getOrElse("tpcds_writes_db_iceberg")
+
+    println(s"LST BENCH DATA DIR is $lstBenchDataDir")
+    println(s"DELTA MERGE SOURCES DIR is $deltaMergeSourcesDir")
+
+    // Temp database for the hive tables
+    val tempDatabaseName = databaseName + "_temp_hive"
+
+    val spark = SparkSession
+      .builder
+      .appName(s"TPCDS SQL Benchmark create tables for write benchmark with scale $scaleFactor GB and $format format")
+      .getOrCreate()
+
+    if (onlyWarn) {
+      println(s"Only WARN")
+      LogManager.getLogger("org").setLevel(Level.WARN)
+    }
+
+    val inputs = Seq(
+      "web_returns_file005_match000_notmatch005",
+      "web_returns_file005_match000_notmatch010",
+      "web_returns_file005_match000_notmatch050",
+      "web_returns_file005_match000_notmatch100",
+      "web_returns_file005_match001_notmatch010",
+      "web_returns_file005_match005_notmatch000",
+      "web_returns_file005_match010_notmatch000",
+      "web_returns_file005_match100_notmatch001",
+      "web_returns_file005_match010_notmatch010",
+      "web_returns_file005_match050_notmatch001",
+      "web_returns_file005_match099_notmatch001",
+      "web_returns_file050_match001_notmatch0001",
+      "web_returns_file100_match001_notmatch0001"
+    )
+
+    val lstSourceToCopy = Seq(
+      ("catalog_returns", catalog_returns_ddl),
+      ("catalog_sales", catalog_sales_ddl),
+      ("inventory", inventory_ddl),
+      ("store_returns", store_returns_ddl),
+      ("store_sales", store_sales_ddl),
+      ("web_returns", web_returns_ddl),
+      ("web_sales", web_sales_ddl),
+      ("date_dim", date_dim_ddl)
+    )
+
+    // Copy delta merge sources to the destination location
+    val deltaCPS3Command = Seq("s3-dist-cp", "--src", deltaMergeSourcesDir, "--dest", s"$s3PathPrefixDestinationDir/$tempDatabaseName")
+    val deltaCPOutput = deltaCPS3Command.!
+    if (deltaCPOutput != 0) {
+      println("Failed to copy over delta merge sources")
+      sys.exit(-1)
+    }
+
+    // Create a temp database for hive tables
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS $tempDatabaseName")
+    spark.sql(s"USE $tempDatabaseName")
+    spark.sql("show tables").show()
+
+    // Create hive tables for the delta merge sources
+    inputs.foreach { tableName =>
+      val sqlForTable = createDeltaMergeSourceSql
+        .replace("tableName", tableName)
+        .replace("s3PathPrefix", s3PathPrefixDestinationDir)
+        .replace("s3PathTargetDatabase", tempDatabaseName)
+      spark.sql(sqlForTable).show()
+    }
+
+    // Create LST merge tables
+    val tasks = for ((tableName, ddl) <- lstSourceToCopy) yield Future {
+      val s3CPCommand = Seq("s3-dist-cp", "--src", s"$lstBenchDataDir/$tableName", "--dest", s"$s3PathPrefixDestinationDir/$tempDatabaseName/$tableName")
+      val output = s3CPCommand.!
+      if (output != 0) {
+        println("Failed to copy over LST data")
+        sys.exit(-1)
+      }
+      val sqlForTable = ddl
+        .replace("s3PathPrefix", s3PathPrefixDestinationDir)
+        .replace("s3PathTargetDatabase", tempDatabaseName)
+      spark.sql(sqlForTable).show()
+      if (!tableName.contains("date_dim")) {
+        spark.sql(s"MSCK REPAIR TABLE $tableName").show()
+      }
+      println(s"Finish: $tableName")
+    }
+    val allTasks = Future.sequence(tasks)
+    println("Awaiting creation...")
+    Await.result(allTasks, 36000.seconds)
+
+
+    // Create Hive tables for merge targets
+    // q0 is for warming up cluster
+    val deltaMergeTargetTasks = for (index <- 0 to 16) yield Future {
+      val s3Command = Seq("s3-dist-cp", "--src", s"$s3PathPrefixDestinationDir/$tempDatabaseName/web_returns/", "--dest", s"$s3PathPrefixDestinationDir/$tempDatabaseName/web_returns_q$index/")
+      s3Command.!!
+      val sqlForTable = createDeltaMergeTargetTableSql
+        .replace("tableName", s"web_returns_q$index")
+        .replace("s3PathPrefix", s3PathPrefixDestinationDir)
+        .replace("s3PathTargetDatabase", tempDatabaseName)
+      spark.sql(sqlForTable)
+      spark.sql(s"MSCK REPAIR TABLE web_returns_q$index")
+      println(s"Finish: web_returns_q$index")
+      index
+    }
+
+    val allDeltaMergeTargetTasks = Future.sequence(deltaMergeTargetTasks)
+
+    println("Awaiting creation...")
+    Await.result(allDeltaMergeTargetTasks, 36000.seconds)
+    println("Finished creation...")
+    spark.sql("show tables").show()
+
+
+    // Create Iceberg tables
+    spark.sql(s"CREATE DATABASE IF NOT EXISTS hadoop_catalog.$databaseName")
+    val tables = spark.sql("show tables")
+    tables.collect().map(r => r(1).toString).foreach(t => {
+      val source_table = "source_table => 'spark_catalog." + tempDatabaseName + "." + t + "', "
+      val target_table = "table => 'hadoop_catalog." + databaseName + t + "', "
+      val location = "location => '" + s3PathPrefixDestinationDir + "/" + databaseName + "/" + t + "_iceberg/" + "'"
+      if (true) {
+        val command = "CALL iceberg.system.snapshot(" +
+          source_table +
+          target_table +
+          location +
+          ")"
+        spark.sql(command)
+        Thread.sleep(64000)
+      }
+    })
+
+    spark.sql("show tables from").show()
+
+    sys.exit(0)
+  }
+}

--- a/benchmark/src/main/scala/com/amazonaws/eks/tpcds/TpcdsDdlStatements.scala
+++ b/benchmark/src/main/scala/com/amazonaws/eks/tpcds/TpcdsDdlStatements.scala
@@ -1,0 +1,398 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+package com.amazonaws.eks.tpcds
+
+object TpcdsDdlStatements {
+  val web_returns_ddl = """
+     CREATE EXTERNAL TABLE web_returns(
+       wr_returned_time_sk int,
+       wr_item_sk int,
+       wr_refunded_customer_sk int,
+       wr_refunded_cdemo_sk int,
+       wr_refunded_hdemo_sk int,
+       wr_refunded_addr_sk int,
+       wr_returning_customer_sk int,
+       wr_returning_cdemo_sk int,
+       wr_returning_hdemo_sk int,
+       wr_returning_addr_sk int,
+       wr_web_page_sk int,
+       wr_reason_sk int,
+       wr_order_number bigint,
+       wr_return_quantity int,
+       wr_return_amt decimal(7,2),
+       wr_return_tax decimal(7,2),
+       wr_return_amt_inc_tax decimal(7,2),
+       wr_fee decimal(7,2),
+       wr_return_ship_cost decimal(7,2),
+       wr_refunded_cash decimal(7,2),
+       wr_reversed_charge decimal(7,2),
+       wr_account_credit decimal(7,2),
+       wr_net_loss decimal(7,2))
+     PARTITIONED BY (
+       wr_returned_date_sk int)
+     ROW FORMAT SERDE
+       'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+     WITH SERDEPROPERTIES (
+       'path'='s3PathPrefix/s3PathTargetDatabase/web_returns/')
+     STORED AS INPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+     OUTPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+     LOCATION
+       's3PathPrefix/s3PathTargetDatabase/web_returns/'
+   """
+
+  val web_sales_ddl = """
+     CREATE EXTERNAL TABLE web_sales(
+       ws_sold_time_sk int,
+         ws_ship_date_sk int,
+         ws_item_sk int,
+         ws_bill_customer_sk int,
+         ws_bill_cdemo_sk int,
+         ws_bill_hdemo_sk int,
+         ws_bill_addr_sk int,
+         ws_ship_customer_sk int,
+         ws_ship_cdemo_sk int,
+         ws_ship_hdemo_sk int,
+         ws_ship_addr_sk int,
+         ws_web_page_sk int,
+         ws_web_site_sk int,
+         ws_ship_mode_sk int,
+         ws_warehouse_sk int,
+         ws_promo_sk int,
+         ws_order_number bigint,
+         ws_quantity int,
+         ws_wholesale_cost decimal(7,2),
+         ws_list_price decimal(7,2),
+         ws_sales_price decimal(7,2),
+         ws_ext_discount_amt decimal(7,2),
+         ws_ext_sales_price decimal(7,2),
+         ws_ext_wholesale_cost decimal(7,2),
+         ws_ext_list_price decimal(7,2),
+         ws_ext_tax decimal(7,2),
+         ws_coupon_amt decimal(7,2),
+         ws_ext_ship_cost decimal(7,2),
+         ws_net_paid decimal(7,2),
+         ws_net_paid_inc_tax decimal(7,2),
+         ws_net_paid_inc_ship decimal(7,2),
+         ws_net_paid_inc_ship_tax decimal(7,2),
+         ws_net_profit decimal(7,2))
+       PARTITIONED BY (
+         ws_sold_date_sk int)
+     ROW FORMAT SERDE
+       'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+     WITH SERDEPROPERTIES (
+       'path'='s3PathPrefix/s3PathTargetDatabase/web_sales/')
+     STORED AS INPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+     OUTPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+     LOCATION
+       's3PathPrefix/s3PathTargetDatabase/web_sales/'
+   """
+
+  val store_returns_ddl = """
+     CREATE EXTERNAL TABLE store_returns(
+       sr_return_time_sk int,
+         sr_item_sk int,
+         sr_customer_sk int,
+         sr_cdemo_sk int,
+         sr_hdemo_sk int,
+         sr_addr_sk int,
+         sr_store_sk int,
+         sr_reason_sk int,
+         sr_ticket_number bigint,
+         sr_return_quantity int,
+         sr_return_amt decimal(7,2),
+         sr_return_tax decimal(7,2),
+         sr_return_amt_inc_tax decimal(7,2),
+         sr_fee decimal(7,2),
+         sr_return_ship_cost decimal(7,2),
+         sr_refunded_cash decimal(7,2),
+         sr_reversed_charge decimal(7,2),
+         sr_store_credit decimal(7,2),
+         sr_net_loss decimal(7,2))
+       PARTITIONED BY (
+         sr_returned_date_sk int)
+     ROW FORMAT SERDE
+       'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+     WITH SERDEPROPERTIES (
+       'path'='s3PathPrefix/s3PathTargetDatabase/store_returns/')
+     STORED AS INPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+     OUTPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+     LOCATION
+       's3PathPrefix/s3PathTargetDatabase/store_returns/'
+   """
+
+  val store_sales_ddl = """
+     CREATE EXTERNAL TABLE store_sales(
+       ss_sold_time_sk int,
+         ss_item_sk int,
+         ss_customer_sk int,
+         ss_cdemo_sk int,
+         ss_hdemo_sk int,
+         ss_addr_sk int,
+         ss_store_sk int,
+         ss_promo_sk int,
+         ss_ticket_number bigint,
+         ss_quantity int,
+         ss_wholesale_cost decimal(7,2),
+         ss_list_price decimal(7,2),
+         ss_sales_price decimal(7,2),
+         ss_ext_discount_amt decimal(7,2),
+         ss_ext_sales_price decimal(7,2),
+         ss_ext_wholesale_cost decimal(7,2),
+         ss_ext_list_price decimal(7,2),
+         ss_ext_tax decimal(7,2),
+         ss_coupon_amt decimal(7,2),
+         ss_net_paid decimal(7,2),
+         ss_net_paid_inc_tax decimal(7,2),
+         ss_net_profit decimal(7,2))
+       PARTITIONED BY (
+         ss_sold_date_sk int)
+     ROW FORMAT SERDE
+       'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+     WITH SERDEPROPERTIES (
+       'path'='s3PathPrefix/s3PathTargetDatabase/store_sales/')
+     STORED AS INPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+     OUTPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+     LOCATION
+       's3PathPrefix/s3PathTargetDatabase/store_sales/'
+   """
+
+  val catalog_returns_ddl = """
+     CREATE EXTERNAL TABLE catalog_returns(
+       cr_returned_time_sk int,
+         cr_item_sk int,
+         cr_refunded_customer_sk int,
+         cr_refunded_cdemo_sk int,
+         cr_refunded_hdemo_sk int,
+         cr_refunded_addr_sk int,
+         cr_returning_customer_sk int,
+         cr_returning_cdemo_sk int,
+         cr_returning_hdemo_sk int,
+         cr_returning_addr_sk int,
+         cr_call_center_sk int,
+         cr_catalog_page_sk int,
+         cr_ship_mode_sk int,
+         cr_warehouse_sk int,
+         cr_reason_sk int,
+         cr_order_number bigint,
+         cr_return_quantity int,
+         cr_return_amount decimal(7,2),
+         cr_return_tax decimal(7,2),
+         cr_return_amt_inc_tax decimal(7,2),
+         cr_fee decimal(7,2),
+         cr_return_ship_cost decimal(7,2),
+         cr_refunded_cash decimal(7,2),
+         cr_reversed_charge decimal(7,2),
+         cr_store_credit decimal(7,2),
+         cr_net_loss decimal(7,2))
+       PARTITIONED BY (
+         cr_returned_date_sk int)
+     ROW FORMAT SERDE
+       'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+     WITH SERDEPROPERTIES (
+       'path'='s3PathPrefix/s3PathTargetDatabase/catalog_returns/')
+     STORED AS INPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+     OUTPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+     LOCATION
+       's3PathPrefix/s3PathTargetDatabase/catalog_returns/'
+   """
+
+  val catalog_sales_ddl = """
+     CREATE EXTERNAL TABLE catalog_sales(
+       cs_sold_time_sk int,
+         cs_ship_date_sk int,
+         cs_bill_customer_sk int,
+         cs_bill_cdemo_sk int,
+         cs_bill_hdemo_sk int,
+         cs_bill_addr_sk int,
+         cs_ship_customer_sk int,
+         cs_ship_cdemo_sk int,
+         cs_ship_hdemo_sk int,
+         cs_ship_addr_sk int,
+         cs_call_center_sk int,
+         cs_catalog_page_sk int,
+         cs_ship_mode_sk int,
+         cs_warehouse_sk int,
+         cs_item_sk int,
+         cs_promo_sk int,
+         cs_order_number bigint,
+         cs_quantity int,
+         cs_wholesale_cost decimal(7,2),
+         cs_list_price decimal(7,2),
+         cs_sales_price decimal(7,2),
+         cs_ext_discount_amt decimal(7,2),
+         cs_ext_sales_price decimal(7,2),
+         cs_ext_wholesale_cost decimal(7,2),
+         cs_ext_list_price decimal(7,2),
+         cs_ext_tax decimal(7,2),
+         cs_coupon_amt decimal(7,2),
+         cs_ext_ship_cost decimal(7,2),
+         cs_net_paid decimal(7,2),
+         cs_net_paid_inc_tax decimal(7,2),
+         cs_net_paid_inc_ship decimal(7,2),
+         cs_net_paid_inc_ship_tax decimal(7,2),
+         cs_net_profit decimal(7,2))
+       PARTITIONED BY (
+         cs_sold_date_sk int)
+     ROW FORMAT SERDE
+       'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+     WITH SERDEPROPERTIES (
+       'path'='s3PathPrefix/s3PathTargetDatabase/catalog_sales/')
+     STORED AS INPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+     OUTPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+     LOCATION
+       's3PathPrefix/s3PathTargetDatabase/catalog_sales/'
+   """
+
+  val inventory_ddl = """
+     CREATE EXTERNAL TABLE inventory(
+       inv_item_sk int,
+         inv_warehouse_sk int,
+         inv_quantity_on_hand int)
+       PARTITIONED BY (
+         inv_date_sk int)
+     ROW FORMAT SERDE
+       'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+     WITH SERDEPROPERTIES (
+       'path'='s3PathPrefix/s3PathTargetDatabase/inventory/')
+     STORED AS INPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+     OUTPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+     LOCATION
+       's3PathPrefix/s3PathTargetDatabase/inventory/'
+   """
+
+  val date_dim_ddl = """
+     CREATE EXTERNAL TABLE date_dim(
+       d_date_sk int,
+         d_date_id string,
+         d_date date,
+         d_month_seq int,
+         d_week_seq int,
+         d_quarter_seq int,
+         d_year int,
+         d_dow int,
+         d_moy int,
+         d_dom int,
+         d_qoy int,
+         d_fy_year int,
+         d_fy_quarter_seq int,
+         d_fy_week_seq int,
+         d_day_name string,
+         d_quarter_name string,
+         d_holiday string,
+         d_weekend string,
+         d_following_holiday string,
+         d_first_dom int,
+         d_last_dom int,
+         d_same_day_ly int,
+         d_same_day_lq int,
+         d_current_day string,
+         d_current_week string,
+         d_current_month string,
+         d_current_quarter string,
+         d_current_year string)
+     ROW FORMAT SERDE
+       'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+     WITH SERDEPROPERTIES (
+       'path'='s3PathPrefix/s3PathTargetDatabase/date_dim/')
+     STORED AS INPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+     OUTPUTFORMAT
+       'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+     LOCATION
+       's3PathPrefix/s3PathTargetDatabase/date_dim/'
+   """
+
+  // This is the target table for delta lake merge DML benchmarks
+  val createDeltaMergeSourceSql = """
+    CREATE EXTERNAL TABLE tableName(
+      wr_returned_time_sk int,
+      wr_item_sk double,
+      wr_refunded_customer_sk int,
+      wr_refunded_cdemo_sk int,
+      wr_refunded_hdemo_sk int,
+      wr_refunded_addr_sk int,
+      wr_returning_customer_sk int,
+      wr_returning_cdemo_sk int,
+      wr_returning_hdemo_sk int,
+      wr_returning_addr_sk int,
+      wr_web_page_sk int,
+      wr_reason_sk int,
+      wr_order_number double,
+      wr_return_quantity int,
+      wr_return_amt decimal(7,2),
+      wr_return_tax decimal(7,2),
+      wr_return_amt_inc_tax decimal(7,2),
+      wr_fee decimal(7,2),
+      wr_return_ship_cost decimal(7,2),
+      wr_refunded_cash decimal(7,2),
+      wr_reversed_charge decimal(7,2),
+      wr_account_credit decimal(7,2),
+      wr_net_loss decimal(7,2),
+      wr_returned_date_sk int)
+    ROW FORMAT SERDE
+      'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+    WITH SERDEPROPERTIES (
+      'path'='s3PathPrefix/s3PathTargetDatabase/tableName/')
+    STORED AS INPUTFORMAT
+      'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+    OUTPUTFORMAT
+      'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+    LOCATION
+      's3PathPrefix/s3PathTargetDatabase/tableName/'
+  """
+
+  // This is the target table for delta lake merge DML benchmarks
+  val createDeltaMergeTargetTableSql = """
+    CREATE EXTERNAL TABLE tableName(
+      wr_returned_time_sk int,
+      wr_item_sk int,
+      wr_refunded_customer_sk int,
+      wr_refunded_cdemo_sk int,
+      wr_refunded_hdemo_sk int,
+      wr_refunded_addr_sk int,
+      wr_returning_customer_sk int,
+      wr_returning_cdemo_sk int,
+      wr_returning_hdemo_sk int,
+      wr_returning_addr_sk int,
+      wr_web_page_sk int,
+      wr_reason_sk int,
+      wr_order_number bigint,
+      wr_return_quantity int,
+      wr_return_amt decimal(7,2),
+      wr_return_tax decimal(7,2),
+      wr_return_amt_inc_tax decimal(7,2),
+      wr_fee decimal(7,2),
+      wr_return_ship_cost decimal(7,2),
+      wr_refunded_cash decimal(7,2),
+      wr_reversed_charge decimal(7,2),
+      wr_account_credit decimal(7,2),
+      wr_net_loss decimal(7,2))
+    PARTITIONED BY (
+      wr_returned_date_sk int)
+    ROW FORMAT SERDE
+      'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+    WITH SERDEPROPERTIES (
+      'path'='s3PathPrefix/s3PathTargetDatabase/tableName/')
+    STORED AS INPUTFORMAT
+      'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+    OUTPUTFORMAT
+      'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+    LOCATION
+      's3PathPrefix/s3PathTargetDatabase/tableName/'
+  """
+}

--- a/docker/benchmark-util/Dockerfile
+++ b/docker/benchmark-util/Dockerfile
@@ -17,7 +17,13 @@ RUN yum update -y && \
 FROM mozilla/sbt:8u292_1.5.4 AS sbtenv
 
 # Build the Databricks SQL perf library from the local Spark version
-RUN git clone -b tpcds-v2.13_iceberg https://github.com/aws-samples/emr-on-eks-benchmark.git /tmp/emr-on-eks-benchmark
+RUN git clone -b tpcds-v2.13_iceberg https://github.com/aws-samples/emr-on-eks-benchmark.git /tmp/emr-on-eks-benchmark && \
+    rm -rf /tmp/emr-on-eks-benchmark/spark-sql-perf && \
+    rm -rf /tmp/emr-on-eks-benchmark/benchmark && \
+    rm -rf /tmp/emr-on-eks-benchmark/delta-perf
+ADD spark-sql-perf /tmp/emr-on-eks-benchmark/spark-sql-perf
+ADD benchmark /tmp/emr-on-eks-benchmark/benchmark
+ADD delta-perf /tmp/emr-on-eks-benchmark/delta-perf
 RUN cd /tmp/emr-on-eks-benchmark/spark-sql-perf/ && sbt +package
 
 # Use the compiled Databricks SQL perf library to build benchmark utility

--- a/docker/hadoop-aws-3.3.1/Dockerfile
+++ b/docker/hadoop-aws-3.3.1/Dockerfile
@@ -1,6 +1,6 @@
 # // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # // SPDX-License-Identifier: MIT-0
-FROM openjdk:8-jdk-slim AS builder
+FROM eclipse-temurin:8-jdk AS builder
 
 # set desired spark, hadoop and kubernetes client versions
 ARG SPARK_VERSION=3.2.1
@@ -27,7 +27,7 @@ WORKDIR /hadoop/share/hadoop/tools/lib
 # # Add additional jar for Hadoop S3a committer
 # ADD https://repository.cloudera.com/artifactory/cloudera-repos/org/apache/spark/spark-hadoop-cloud_2.12/3.1.1.3.1.7270.0-253/spark-hadoop-cloud_2.12-3.1.1.3.1.7270.0-253.jar .
 
-FROM openjdk:8-jdk-slim AS final
+FROM eclipse-temurin:8-jdk AS final
 WORKDIR /opt/spark
 
 # Copy Spark from builder stage
@@ -57,9 +57,9 @@ ENV SPARK_EXTRA_CLASSPATH="$SPARK_DIST_CLASSPATH"
 ENV LD_LIBRARY_PATH=/lib64
 
 # Create a Hadoop user/group
-RUN addgroup -gid 1000 hadoop && \
-useradd -u 1000 -g hadoop -m -s /bin/sh hadoop && \
-echo "hadoop:hadoop" | chpasswd
+RUN (groupadd -g 1000 hadoop 2>/dev/null || groupmod -n hadoop $(getent group 1000 | cut -d: -f1)) && \
+    (useradd -u 1000 -g 1000 -m -s /bin/bash hadoop 2>/dev/null || usermod -l hadoop -d /home/hadoop -m $(getent passwd 1000 | cut -d: -f1)) && \
+    echo "hadoop:hadoop" | chpasswd
 USER hadoop:hadoop
 ENV SPARK_USER=hadoop
 

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m1.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m1.sql
@@ -1,0 +1,4 @@
+MERGE INTO web_returns_q1 t
+    USING web_returns_file005_match000_notmatch005 s
+    ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+    WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m1.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m1.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q1 t
     USING web_returns_file005_match000_notmatch005 s
     ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m10.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m10.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q10 t
+        USING web_returns_file005_match010_notmatch010 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m10.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m10.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q10 t
         USING web_returns_file005_match010_notmatch010 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m11.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m11.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q11 t
+        USING web_returns_file005_match050_notmatch001 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m11.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m11.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q11 t
         USING web_returns_file005_match050_notmatch001 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m12.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m12.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q12 t
         USING web_returns_file005_match099_notmatch001 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m12.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m12.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q12 t
+        USING web_returns_file005_match099_notmatch001 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m13.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m13.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q13 t
         USING web_returns_file005_match100_notmatch001 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m13.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m13.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q13 t
+        USING web_returns_file005_match100_notmatch001 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m14.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m14.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q14 t
+        USING web_returns_file005_match010_notmatch000 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m14.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m14.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q14 t
         USING web_returns_file005_match010_notmatch000 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m15.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m15.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q15 t
+        USING web_returns_file050_match001_notmatch0001 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m15.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m15.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q15 t
         USING web_returns_file050_match001_notmatch0001 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m16.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m16.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q16 t
+        USING web_returns_file100_match001_notmatch0001 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m16.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m16.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q16 t
         USING web_returns_file100_match001_notmatch0001 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m17.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m17.sql
@@ -1,0 +1,14 @@
+MERGE INTO
+    catalog_returns
+        USING(
+        SELECT
+            cs_order_number
+        FROM
+            catalog_sales,
+            date_dim
+        WHERE
+            cs_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '2000-05-20' AND '2000-05-21'
+    ) SOURCE ON
+    cr_order_number = cs_order_number
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m17.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m17.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     catalog_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m18.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m18.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     catalog_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m18.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m18.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    catalog_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2000-05-20' AND '2000-05-21'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2000-05-20' AND '2000-05-21'
+            ) s
+    ) SOURCE ON
+    cs_sold_date_sk >= min_date
+    AND cs_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m19.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m19.sql
@@ -1,0 +1,16 @@
+MERGE INTO
+    catalog_returns
+        USING(
+        SELECT
+            cs_order_number
+        FROM
+            catalog_sales,
+            date_dim
+        WHERE
+            cs_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '1999-09-18' AND '1999-09-19'
+    ) SOURCE ON
+    cr_order_number = cs_order_number
+    WHEN MATCHED THEN DELETE;
+
+

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m19.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m19.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     catalog_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m2.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m2.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q2 t
         USING web_returns_file005_match000_notmatch050 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m2.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m2.sql
@@ -1,0 +1,4 @@
+MERGE INTO web_returns_q2 t
+        USING web_returns_file005_match000_notmatch050 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m20.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m20.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     catalog_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m20.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m20.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    catalog_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '1999-09-18' AND '1999-09-19'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '1999-09-18' AND '1999-09-19'
+            ) s
+    ) SOURCE ON
+    cs_sold_date_sk >= min_date
+    AND cs_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m21.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m21.sql
@@ -1,0 +1,14 @@
+MERGE INTO
+    catalog_returns
+        USING(
+        SELECT
+            cs_order_number
+        FROM
+            catalog_sales,
+            date_dim
+        WHERE
+            cs_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '2002-11-12' AND '2002-11-13'
+    ) SOURCE ON
+    cr_order_number = cs_order_number
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m21.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m21.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     catalog_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m22.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m22.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     catalog_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m22.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m22.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    catalog_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2002-11-12' AND '2002-11-13'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2002-11-12' AND '2002-11-13'
+            ) s
+    ) SOURCE ON
+    cs_sold_date_sk >= min_date
+    AND cs_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m23.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m23.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     inventory
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m23.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m23.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    inventory
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2000-05-18' AND '2000-05-25'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2000-05-18' AND '2000-05-25'
+            ) s
+    ) SOURCE ON
+    inv_date_sk >= min_date
+    AND inv_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m24.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m24.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     inventory
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m24.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m24.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    inventory
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '1999-09-16' AND '1999-09-23'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '1999-09-16' AND '1999-09-23'
+            ) s
+    ) SOURCE ON
+    inv_date_sk >= min_date
+    AND inv_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m25.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m25.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     inventory
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m25.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m25.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    inventory
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2002-11-14' AND '2002-11-21'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2002-11-14' AND '2002-11-21'
+            ) s
+    ) SOURCE ON
+    inv_date_sk >= min_date
+    AND inv_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m26.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m26.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     store_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m26.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m26.sql
@@ -1,0 +1,14 @@
+MERGE INTO
+    store_returns
+        USING(
+        SELECT
+            ss_ticket_number
+        FROM
+            store_sales,
+            date_dim
+        WHERE
+            ss_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '2000-05-20' AND '2000-05-21'
+    ) SOURCE ON
+    sr_ticket_number = ss_ticket_number
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m27.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m27.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    store_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2000-05-20' AND '2000-05-21'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2000-05-20' AND '2000-05-21'
+            ) s
+    ) SOURCE ON
+    ss_sold_date_sk >= min_date
+    AND ss_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m27.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m27.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     store_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m28.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m28.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     store_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m28.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m28.sql
@@ -1,0 +1,14 @@
+MERGE INTO
+    store_returns
+        USING(
+        SELECT
+            ss_ticket_number
+        FROM
+            store_sales,
+            date_dim
+        WHERE
+            ss_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '1999-09-18' AND '1999-09-19'
+    ) SOURCE ON
+    sr_ticket_number = ss_ticket_number
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m29.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m29.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     store_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m29.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m29.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    store_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '1999-09-18' AND '1999-09-19'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '1999-09-18' AND '1999-09-19'
+            ) s
+    ) SOURCE ON
+    ss_sold_date_sk >= min_date
+    AND ss_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m3.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m3.sql
@@ -1,0 +1,4 @@
+MERGE INTO web_returns_q3 t
+        USING web_returns_file005_match000_notmatch100 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m3.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m3.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q3 t
         USING web_returns_file005_match000_notmatch100 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m30.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m30.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     store_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m30.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m30.sql
@@ -1,0 +1,14 @@
+MERGE INTO
+    store_returns
+        USING(
+        SELECT
+            ss_ticket_number
+        FROM
+            store_sales,
+            date_dim
+        WHERE
+            ss_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '2002-11-12' AND '2002-11-13'
+    ) SOURCE ON
+    sr_ticket_number = ss_ticket_number
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m31.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m31.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     store_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m31.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m31.sql
@@ -1,0 +1,27 @@
+MERGE INTO
+    store_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2002-11-12' AND '2002-11-13'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2002-11-12' AND '2002-11-13'
+            ) s
+    ) SOURCE ON
+    ss_sold_date_sk >= min_date
+    AND ss_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;
+

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m32.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m32.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     web_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m32.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m32.sql
@@ -1,0 +1,14 @@
+MERGE INTO
+    web_returns
+        USING(
+        SELECT
+            ws_order_number
+        FROM
+            web_sales,
+            date_dim
+        WHERE
+            ws_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '2000-05-20' AND '2000-05-21'
+    ) SOURCE ON
+    wr_order_number = ws_order_number
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m33.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m33.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     web_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m33.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m33.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    web_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2000-05-20' AND '2000-05-21'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2000-05-20' AND '2000-05-21'
+            ) s
+    ) SOURCE ON
+    ws_sold_date_sk >= min_date
+    AND ws_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m34.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m34.sql
@@ -1,0 +1,14 @@
+MERGE INTO
+    web_returns
+        USING(
+        SELECT
+            ws_order_number
+        FROM
+            web_sales,
+            date_dim
+        WHERE
+            ws_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '1999-09-18' AND '1999-09-19'
+    ) SOURCE ON
+    wr_order_number = ws_order_number
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m34.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m34.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     web_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m35.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m35.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    web_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '1999-09-18' AND '1999-09-19'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '1999-09-18' AND '1999-09-19'
+            ) s
+    ) SOURCE ON
+    ws_sold_date_sk >= min_date
+    AND ws_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m35.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m35.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     web_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m36.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m36.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     web_returns
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m36.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m36.sql
@@ -1,0 +1,14 @@
+MERGE INTO
+    web_returns
+        USING(
+        SELECT
+            ws_order_number
+        FROM
+            web_sales,
+            date_dim
+        WHERE
+            ws_sold_date_sk = d_date_sk
+            AND d_date BETWEEN '2002-11-12' AND '2002-11-13'
+    ) SOURCE ON
+    wr_order_number = ws_order_number
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m37.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m37.sql
@@ -1,0 +1,26 @@
+MERGE INTO
+    web_sales
+        USING(
+        SELECT
+            *
+        FROM
+            (
+                SELECT
+                    MIN( d_date_sk ) AS min_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2002-11-12' AND '2002-11-13'
+            ) r
+        JOIN(
+                SELECT
+                    MAX( d_date_sk ) AS max_date
+                FROM
+                    date_dim
+                WHERE
+                    d_date BETWEEN '2002-11-12' AND '2002-11-13'
+            ) s
+    ) SOURCE ON
+    ws_sold_date_sk >= min_date
+    AND ws_sold_date_sk <= max_date
+    WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m37.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m37.sql
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 MERGE INTO
     web_sales
         USING(

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m4.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m4.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q4 t
+        USING web_returns_file005_match000_notmatch005 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN NOT MATCHED AND s.wr_item_sk % 2 = 0 THEN INSERT *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m4.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m4.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q4 t
         USING web_returns_file005_match000_notmatch005 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m5.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m5.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q5 t
+        USING web_returns_file005_match000_notmatch050 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN NOT MATCHED AND s.wr_item_sk % 2 = 0 THEN INSERT *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m5.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m5.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q5 t
         USING web_returns_file005_match000_notmatch050 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m6.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m6.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q6 t
+        USING web_returns_file005_match000_notmatch100 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN NOT MATCHED AND s.wr_item_sk % 2 = 0 THEN INSERT *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m6.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m6.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q6 t
         USING web_returns_file005_match000_notmatch100 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m7.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m7.sql
@@ -1,0 +1,4 @@
+MERGE INTO web_returns_q7 t
+        USING web_returns_file005_match005_notmatch000 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN DELETE;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m7.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m7.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q7 t
         USING web_returns_file005_match005_notmatch000 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m8.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m8.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q8 t
+        USING web_returns_file005_match000_notmatch010 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m8.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m8.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q8 t
         USING web_returns_file005_match000_notmatch010 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m9.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m9.sql
@@ -1,0 +1,5 @@
+MERGE INTO web_returns_q9 t
+        USING web_returns_file005_match001_notmatch010 s
+        ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *;

--- a/spark-sql-perf/src/main/resources/tpcds_writes/m9.sql
+++ b/spark-sql-perf/src/main/resources/tpcds_writes/m9.sql
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 MERGE INTO web_returns_q9 t
         USING web_returns_file005_match001_notmatch010 s
         ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk

--- a/spark-sql-perf/src/main/scala/com/databricks/spark/sql/perf/tpcds/TPCDS.scala
+++ b/spark-sql-perf/src/main/scala/com/databricks/spark/sql/perf/tpcds/TPCDS.scala
@@ -33,6 +33,7 @@ class TPCDS(@transient sqlContext: SQLContext)
   with Tpcds_1_4_Queries
   with Tpcds_2_4_Queries
   with Tpcds_2_13_Queries
+  with TPCDS_Writes
   with Serializable {
 
   def this() = this(SparkSession.builder.getOrCreate().sqlContext)

--- a/spark-sql-perf/src/main/scala/com/databricks/spark/sql/perf/tpcds/TPCDS_Writes.scala
+++ b/spark-sql-perf/src/main/scala/com/databricks/spark/sql/perf/tpcds/TPCDS_Writes.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Databricks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.sql.perf.tpcds
+
+import com.databricks.spark.sql.perf.{Benchmark, ExecutionMode}
+import com.databricks.spark.sql.perf.ExecutionMode.CollectResults
+import org.apache.commons.io.IOUtils
+
+/**
+* This implements the write benchmarks from LST bench and few other DMLs from Delta write benchmark
+  */
+trait TPCDS_Writes extends Benchmark {
+
+  import ExecutionMode._
+
+  val queryNamesMerge = Seq(
+    "m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9", "m10",
+    "m11", "m12", "m13", "m14", "m15", "m16", "m17", "m18", "m19", "m20",
+    "m21", "m22", "m23", "m24", "m25", "m26", "m27", "m28", "m29", "m30",
+    "m31", "m32", "m33", "m34", "m35", "m36", "m37"
+  )
+
+  val mergeQueries = queryNamesMerge.map { queryName =>
+    val queryContent: String = IOUtils.toString(
+      getClass().getClassLoader().getResourceAsStream(s"tpcds_writes/$queryName.sql"))
+    Query(queryName, queryContent, description = "TPCDS write Query",
+      executionMode = CollectResults)
+  }
+}


### PR DESCRIPTION
*Description of changes:*
* Adds write/merge benchmark framework support
* Modify Spark sql perf to support write benchmarks
* Add scripts to create data and iceberg tables for write benchmark, and clean up tables 
* The write benchmarks DMLs are taken from LST bench (https://github.com/microsoft/lst-bench) and Delta benchmark (https://github.com/delta-io/delta/blob/master/benchmarks/src/main/scala/benchmark/MergeTestCases.scala#L77); Add licensing info.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
