### PR TITLE
Enhance README with Spark version support details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Spark on Kubernetes benchmark utility
 
-This repository provides a general tool to benchmark Spark performance.
-If you want to use the [prebuild docker image](https://github.com/aws-samples/emr-on-eks-benchmark/pkgs/container/emr-on-eks-benchmark) based on a prebuild OSS spark_3.1.2_hadoop_3.3.1, you can skip the [build section](#Build-benchmark-utility-docker-image) and jump to [Run Benchmark](#Run-Benchmark) directly. If you want to build your own, follow the steps in the [build section](#Build-benchmark-utility-docker-image).
+This repository provides a general tool to benchmark Spark performance. It supports Spark 2.x, Spark 3.x, and Spark 4.x (scala2.13), along with the corresponding Scala versions. Before build docker images, please clone the branch that matches your target Spark version.
+If you want to use the [prebuild docker image](https://github.com/aws-samples/emr-on-eks-benchmark/pkgs/container/eks-spark-benchmark) based on a prebuild OSS spark_3.1.2_hadoop_3.3.1, you can skip the [build section](#Build-benchmark-utility-docker-image) and jump to [Run Benchmark](#Run-Benchmark) directly. If you want to build your own, follow the steps in the [build section](#Build-benchmark-utility-docker-image).
 
 ## Prerequisite
 


### PR DESCRIPTION
Updated README to include support for Spark 2.x, 3.x, and 4.x, and clarified instructions for building Docker images.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
